### PR TITLE
Adds styles to scale image in different ways

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,8 +32,11 @@ class: slide-title
 
 <p>Text before diagram</p>
 
-<figure>
-<img src="recursive_evaluation.svg" alt="Recursive evaluation of an expression tree"/>
+<figure class="scaled-figure">
+<!-- Use container to center image using flexbox -->
+<div class="container">
+<img class="scaled-img" src="recursive_evaluation.svg" alt="Recursive evaluation of an expression tree"/>
+</div>
 </figure>
 
 <p>Text after diagram</p>

--- a/mccole.css
+++ b/mccole.css
@@ -229,6 +229,11 @@ figure {
     margin-inline-end: 0px;
 }
 
+figure.scaled-figure {
+    display: flex;
+    justify-content: center;
+}
+
 /*
  * Images.
  */
@@ -245,6 +250,26 @@ img.image {
 
 figure.fullwidth img {
     width: 100%;
+}
+
+img.scaled-img {
+    /*
+        Setting the width to an explicit number provides an independent container element and
+        everything works correctly.
+     */
+    /* width: 500px; */
+    /*
+        Setting the width to a percentage increases the size of the of the image, but the width of
+        the image is calculated using the intrinsic size
+        (https://developer.mozilla.org/en-US/docs/Glossary/Intrinsic_Size)
+        during the initial layout phase and doesn't get updated as the image is scaled up.
+     */
+    width: 120%;
+    /* 
+        Using a scale transform increases the size of the image but doesn't update the page layout.
+        As such, the image element will begin to overlap surrounding elements at higher scales.
+     */
+    /* transform: scale(1.6); */
 }
 
 /*


### PR DESCRIPTION
This adds some additional styles to control how the image gets scaled. I added comments to the CSS file describing what happens for each of the three options for scaling the image. You should be able to scale the image up using one of the first two options.

The percentage width option will adjust height properly, but the width [never updates](https://www.w3.org/TR/css-sizing-3/#cyclic-percentage-contribution) after the initial layout phase and therefore the centering using flexbox doesn't look right because it's calculating the position using the original width. If you don't care about centering the image, that's the option I'd use. If you do, I'd use the first option.

Were you using the scale transform before? If so, the overlapping issue makes sense because the layout isn't recalculated when using [CSS transforms](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_transforms/Using_CSS_transforms). You could always use an event listener in JS if you wanted to work around this issue.

Hopefully this helps address the issue you've been having. Let me know if you have any questions.